### PR TITLE
fix: use roblox-user argument type in promote

### DIFF
--- a/src/commands/admin/promote.js
+++ b/src/commands/admin/promote.js
@@ -17,7 +17,7 @@ class PromoteCommand extends BaseCommand {
       args: [{
         key: 'user',
         prompt: 'Who would you like to promote?',
-        type: 'member|string'
+        type: 'roblox-user'
       }]
     })
   }

--- a/src/services/ban.js
+++ b/src/services/ban.js
@@ -18,7 +18,7 @@ async function getBanEmbeds (groupId, bans) {
   return discordService.getListEmbeds(
     'Banlist',
     bans,
-    exports.getBanRow,
+    getBanRow,
     { users, roles }
   )
 }
@@ -27,7 +27,7 @@ function getBanRow (ban, { users, roles }) {
   const username = users.find(user => user.id === ban.userId).name
   const author = users.find(user => user.id === ban.authorId)
   const role = roles.roles.find(role => role.rank === ban.rank)
-  const roleAbbreviation = role ? getAbbreviation(role.name) : 'Unknown'
+  const roleAbbreviation = role ? getAbbreviation(role.name) : 'unknown'
   const dateString = getDate(new Date(ban.date))
 
   return `**${username}**${role ? ' (' + roleAbbreviation + ')' : ''}${author ? ' by **' + author.name + '**' : ''}${dateString ? ' at **' + dateString + '**' : ''}${ban.reason ? ' with reason:\n*' + ban.reason + '*' : ''}`

--- a/src/services/group.js
+++ b/src/services/group.js
@@ -25,7 +25,7 @@ async function getTrainingEmbeds (trainings) {
   return discordService.getListEmbeds(
     'Upcoming Trainings',
     trainings,
-    exports.getTrainingRow,
+    getTrainingRow,
     { users }
   )
 }
@@ -50,7 +50,7 @@ async function getSuspensionEmbeds (groupId, suspensions) {
   return discordService.getListEmbeds(
     'Current Suspensions',
     suspensions,
-    exports.getSuspensionRow,
+    getSuspensionRow,
     { users, roles }
   )
 }
@@ -59,7 +59,7 @@ function getSuspensionRow (suspension, { users, roles }) {
   const username = users.find(user => user.id === suspension.userId).name
   const author = users.find(user => user.id === suspension.authorId)
   const role = roles.roles.find(role => role.rank === suspension.rank)
-  const roleAbbreviation = role ? getAbbreviation(role.name) : 'Unknown'
+  const roleAbbreviation = role ? getAbbreviation(role.name) : 'unknown'
   const rankBack = suspension.rankBack ? 'yes' : 'no'
   const dateString = getDate(new Date(suspension.date))
   const days = suspension.duration / 86400000
@@ -71,7 +71,7 @@ function getSuspensionRow (suspension, { users, roles }) {
   }
   const extensionString = extensionDays < 0 ? ` (${extensionDays})` : extensionDays > 0 ? ` (+${extensionDays})` : ''
 
-  return `**${username}** (${roleAbbreviation}, rankback **${rankBack}**) by **${author.name}** at **${dateString}** for **${days}${extensionString} ${pluralize('day', days + extensionDays)}** with reason:\n*${suspension.reason}*`
+  return `**${username}** (${roleAbbreviation}, rankBack **${rankBack}**) by **${author.name}** at **${dateString}** for **${days}${extensionString} ${pluralize('day', days + extensionDays)}** with reason:\n*${suspension.reason}*`
 }
 
 function groupTrainingsByType (trainings) {


### PR DESCRIPTION
This PR fixes two bugs:
- one caused by #220 where promote's user argument type wasn't updated to roblox-user
- one by #164 where the the getListEmbed methods' getRow argument wasn't updated correctly