### PR TITLE
feat: move membercount command to main group

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -61,7 +61,6 @@ class AroraClient extends CommandoClient {
       .registerGroup('admin', 'Admin')
       .registerGroup('bot', 'Bot')
       .registerGroup('main', 'Main')
-      .registerGroup('miscellaneous', 'Miscellaneous')
       .registerGroup('settings', 'Settings')
       .registerTypesIn({ dirname: path.join(__dirname, '../types'), filter: /^(?!base.js).+$/ })
       .registerCommandsIn(path.join(__dirname, '../commands'))

--- a/src/commands/main/member-count.js
+++ b/src/commands/main/member-count.js
@@ -8,7 +8,7 @@ const { groupService } = require('../../services')
 class MemberCountCommand extends BaseCommand {
   constructor (client) {
     super(client, {
-      group: 'miscellaneous',
+      group: 'main',
       name: 'membercount',
       description: 'Posts the current member count of the group.',
       clientPermissions: ['SEND_MESSAGES'],


### PR DESCRIPTION
This moves the `membercount` command to the command group `main` and removes the `miscellaneous` command group.