### PR TITLE
fix: use correct event for payout report

### DIFF
--- a/src/client/websocket/handlers/train-developers-payout-report.js
+++ b/src/client/websocket/handlers/train-developers-payout-report.js
@@ -5,7 +5,7 @@ const pluralize = require('pluralize')
 const { MessageEmbed } = require('discord.js')
 const { userService } = require('../../../services')
 
-const trainDevelopersPayoutHandler = async (client, { data }) => {
+const trainDevelopersPayoutReportHandler = async (client, { data }) => {
   const { developersSales } = data
   const developerIds = Object.keys(developersSales)
   const developers = await userService.getUsers(developerIds)
@@ -38,4 +38,4 @@ const trainDevelopersPayoutHandler = async (client, { data }) => {
   client.owners.forEach(owner => owner.send(embed))
 }
 
-module.exports = trainDevelopersPayoutHandler
+module.exports = trainDevelopersPayoutReportHandler


### PR DESCRIPTION
This PR makes the payoutTrainDeveloperReportHandler use the correct event name that is sent over the WebSocket.