### PR TITLE
refactor: unify edit commands

### DIFF
--- a/src/commands/admin/edit-ban.js
+++ b/src/commands/admin/edit-ban.js
@@ -30,7 +30,7 @@ class EditBanCommand extends BaseCommand {
       }, {
         key: 'data',
         type: 'string',
-        prompt: 'What would you like to change this key\'s data to?'
+        prompt: 'What would you like to edit this key\'s data to?'
       }]
     })
   }

--- a/src/commands/admin/edit-ban.js
+++ b/src/commands/admin/edit-ban.js
@@ -6,25 +6,25 @@ const { applicationAdapter } = require('../../adapters')
 const { userService } = require('../../services')
 const { noChannels, noTags, noUrls } = require('../../util').argumentUtil
 
-class ChangeBanCommand extends BaseCommand {
+class EditBanCommand extends BaseCommand {
   constructor (client) {
     super(client, {
       group: 'admin',
-      name: 'changeban',
-      details: 'Key must be author or reason. You can only change the author of bans you created.',
-      description: 'Changes given user\'s ban\'s key to given data.',
-      examples: ['changeban Happywalker author builderman'],
+      name: 'editban',
+      description: 'Edits given user\'s ban\'s key to given data.',
+      details: 'Key must be author or reason.',
+      examples: ['editban Happywalker author builderman'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresApi: true,
       requiresRobloxGroup: true,
       args: [{
         key: 'user',
         type: 'roblox-user',
-        prompt: 'Whose ban would you like to change?'
+        prompt: 'Whose ban would you like to edit?'
       }, {
         key: 'key',
         type: 'string',
-        prompt: 'What key would you like to change?',
+        prompt: 'What key would you like to edit?',
         oneOf: ['author', 'reason'],
         parse: val => val.toLowerCase()
       }, {
@@ -55,8 +55,8 @@ class ChangeBanCommand extends BaseCommand {
 
     await applicationAdapter('PUT', `v1/groups/${message.guild.robloxGroupId}/bans/${user.id}`, { changes, editorId })
 
-    return message.reply(`Successfully changed **${user.username ?? user.id}**'s ban.`)
+    return message.reply(`Successfully edited **${user.username ?? user.id}**'s ban.`)
   }
 }
 
-module.exports = ChangeBanCommand
+module.exports = EditBanCommand

--- a/src/commands/admin/edit-training.js
+++ b/src/commands/admin/edit-training.js
@@ -7,32 +7,32 @@ const { groupService, userService } = require('../../services')
 const { noChannels, noTags, noUrls, validDate, validTime } = require('../../util').argumentUtil
 const { getDate, getDateInfo, getTime, getTimeInfo } = require('../../util').timeUtil
 
-class ChangeTrainingCommand extends BaseCommand {
+class EditTrainingCommand extends BaseCommand {
   constructor (client) {
     super(client, {
       group: 'admin',
-      name: 'changetraining',
-      details: 'TrainingId must be the ID of a currently scheduled training. Key must be author, type, date, time or ' +
-        'notes.',
-      description: 'Changes given training\'s key to given data.',
-      examples: ['changetraining 1 date 5-3-2020'],
+      name: 'edittraining',
+      description: 'Edits given training\'s key to given data.',
+      details: 'Key must be author, type, date, time or notes. trainingId must be the ID of a currently scheduled ' +
+        'training. ',
+      examples: ['edittraining 1 date 5-3-2020'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresApi: true,
       requiresRobloxGroup: true,
       args: [{
         key: 'trainingId',
         type: 'integer',
-        prompt: 'Which training would you like to change?'
+        prompt: 'Which training would you like to edit?'
       }, {
         key: 'key',
         type: 'string',
-        prompt: 'What key would you like to change?',
+        prompt: 'What key would you like to edit?',
         oneOf: ['author', 'type', 'date', 'time', 'notes'],
         parse: val => val.toLowerCase()
       }, {
         key: 'data',
         type: 'string',
-        prompt: 'What would you like to change this key\'s data to?'
+        prompt: 'What would you like to edit this key\'s data to?'
       }]
     })
   }
@@ -92,8 +92,8 @@ class ChangeTrainingCommand extends BaseCommand {
       editorId
     })
 
-    return message.reply(`Successfully changed training with ID **${trainingId}**.`)
+    return message.reply(`Successfully edited training with ID **${trainingId}**.`)
   }
 }
 
-module.exports = ChangeTrainingCommand
+module.exports = EditTrainingCommand

--- a/src/commands/admin/schedule-training.js
+++ b/src/commands/admin/schedule-training.js
@@ -15,16 +15,16 @@ const {
 } = require('../../util').argumentUtil
 const { getDateInfo, getTimeInfo } = require('../../util').timeUtil
 
-class HostTrainingCommand extends BaseCommand {
+class ScheduleTrainingCommand extends BaseCommand {
   constructor (client) {
     super(client, {
       group: 'admin',
-      name: 'hosttraining',
+      name: 'scheduletraining',
+      aliases: ['schedule'],
       details: 'Type must be CD or CSR. You can add special notes that will be shown in the training\'s announcement.' +
         ' The date argument should be dd-mm-yyyy format.',
-      aliases: ['host'],
       description: 'Schedules a new training.',
-      examples: ['host CD 4-3-2020 1:00 Be on time!', 'Host CSR 4-3-2020 2:00'],
+      examples: ['schedule CD 4-3-2020 1:00 Be on time!', 'schedule CSR 4-3-2020 2:00 none'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresApi: true,
       requiresRobloxGroup: true,
@@ -92,4 +92,4 @@ class HostTrainingCommand extends BaseCommand {
   }
 }
 
-module.exports = HostTrainingCommand
+module.exports = ScheduleTrainingCommand

--- a/src/commands/settings/edit-panel.js
+++ b/src/commands/settings/edit-panel.js
@@ -19,12 +19,12 @@ class EditPanelCommand extends BaseCommand {
       }, {
         key: 'key',
         type: 'string',
-        prompt: 'What key would you like to change?',
+        prompt: 'What key would you like to edit?',
         oneOf: ['content', 'message'],
         parse: val => val.toLowerCase()
       }, {
         key: 'data',
-        prompt: 'What would you like to change this key\'s data to?',
+        prompt: 'What would you like to edit this key\'s data to?',
         type: 'json-object|message'
       }]
     })

--- a/src/commands/settings/permit.js
+++ b/src/commands/settings/permit.js
@@ -59,7 +59,7 @@ class PermitCommand extends BaseCommand {
       const permission = roleOrGroup.aroraPermissions.resolve(commandOrGroup)
       if (permission) {
         await permission.update({ allow })
-        return message.reply(`Successfully changed \`${commandOrGroup.name}\` ${commandType} permission for ${subject} to allow: \`${allow}\`.`, {
+        return message.reply(`Successfully edited \`${commandOrGroup.name}\` ${commandType} permission for ${subject} to allow: \`${allow}\`.`, {
           allowedMentions: { users: [message.author.id] }
         })
       } else {

--- a/src/commands/settings/set-setting.js
+++ b/src/commands/settings/set-setting.js
@@ -18,7 +18,7 @@ class SetSettingCommand extends BaseCommand {
       clientPermissions: ['SEND_MESSAGES'],
       args: [{
         key: 'setting',
-        prompt: 'What setting would you like to change?',
+        prompt: 'What setting would you like to set?',
         type: 'string',
         oneOf: Object.keys(Guild.rawAttributes)
           .filter(attribute => !['id', 'supportEnabled', 'commandPrefix'].includes(attribute))

--- a/src/commands/settings/set-setting.js
+++ b/src/commands/settings/set-setting.js
@@ -27,7 +27,7 @@ class SetSettingCommand extends BaseCommand {
         parse: parseSetting
       }, {
         key: 'value',
-        prompt: 'What would you like to change this setting to? Reply with "none" if you want to reset the setting.',
+        prompt: 'What would you like to set this setting to? Reply with "none" if you want to reset the setting.',
         type: 'category-channel|text-channel|message|integer|boolean|string',
         parse: parseNoneOrType
       }]
@@ -82,7 +82,7 @@ class SetSettingCommand extends BaseCommand {
 
     await message.guild.update({ [setting]: value instanceof GuildChannel ? value.id : value })
 
-    return message.reply(`Successfully changed ${setting.endsWith('Id') ? setting.slice(0, -2) : setting} to ${value instanceof GuildChannel ? value : `\`${setting === 'verificationPreference' ? VerificationProviders[value.toUpperCase()] : value}\``}.`)
+    return message.reply(`Successfully set ${setting.endsWith('Id') ? setting.slice(0, -2) : setting} to ${value instanceof GuildChannel ? value : `\`${setting === 'verificationPreference' ? VerificationProviders[value.toUpperCase()] : value}\``}.`)
   }
 }
 


### PR DESCRIPTION
This PR changes all `change<structure>` commands to `edit<structure>` commands to clarify their use and unify them with the commands in the `settings` command group.

Also `hosttraining` is changed to `scheduletraining` (with alias `schedule`) and these commands' information and outputs are also updated to use "edit" instead of "change".