### PR TITLE
feat: remove closing of legacy ticket channels

### DIFF
--- a/src/commands/settings/close-ticket.js
+++ b/src/commands/settings/close-ticket.js
@@ -40,9 +40,6 @@ class CloseTicketCommand extends BaseCommand {
           ticket.close('The moderator has closed your ticket.', true, message.guild.primaryColor)
         }
       }
-    } else if (message.guild.ticketsCategory && message.channel.parentID === message.guild.ticketsCategoryId &&
-      message.channel.id !== message.guild.ratingsChannelId) {
-      message.channel.delete()
     }
   }
 }


### PR DESCRIPTION
This PR removes the additional conditional in the closeticket command for old ticket channels from before the bot persistence update.

This PR should be merged after the last old ticket channels are closed in the TR server.