### PR TITLE
fix: WSEvents initialization

### DIFF
--- a/src/client/websocket/handlers/index.js
+++ b/src/client/websocket/handlers/index.js
@@ -6,7 +6,7 @@ const { WSEvents } = require('../../../util/constants')
 
 const handlers = {}
 
-for (const name of Object.keys(WSEvents)) {
+for (const name of Object.values(WSEvents)) {
   try {
     handlers[name] = require(`./${lodash.kebabCase(name)}`)
   } catch {} // eslint-disable-line no-empty

--- a/src/util/constants.js
+++ b/src/util/constants.js
@@ -11,7 +11,7 @@ const VerificationProviders = {
 }
 
 const WSEvents = {
-  TRAIN_DEVELOPERS_PAYOUT: 'trainDevelopersPayout',
+  TRAIN_DEVELOPERS_PAYOUT_REPORT: 'trainDevelopersPayoutReport',
   RANK_CHANGE: 'rankChange'
 }
 


### PR DESCRIPTION
Fixes the name of one of the WSEvents and makes the initialization loop use the correct values.