### PR TITLE
feat: init Sentry with environment and release

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,7 +36,7 @@ steps:
           username: buildkite
           password-env: DOCKER_PASSWORD
       - docker-compose#v3.7.0:
-          push: app-production:docker.guidojw.nl/arora/arora-discord:staging
+          push: app-staging:docker.guidojw.nl/arora/arora-discord:staging
           image-name: docker.guidojw.nl/arora/arora-discord:staging
           config: docker-compose.buildkite.yml
 

--- a/app.js
+++ b/app.js
@@ -9,7 +9,11 @@ const AroraClient = require('./src/client/client')
 const healthCheckJobConfig = require('./config/cron').healthCheckJob
 
 if (process.env.SENTRY_DSN) {
-  Sentry.init({ dsn: process.env.SENTRY_DSN })
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    environment: process.env.NODE_ENV,
+    release: process.env.BUILD_HASH
+  })
 }
 
 cron.schedule(

--- a/docker-compose.buildkite.yml
+++ b/docker-compose.buildkite.yml
@@ -5,7 +5,14 @@ services:
     build:
       context: .
       args:
-        NODE_ENV: test
+        - NODE_ENV=test
+    environment:
+      - BUILD_HASH=${BUILDKITE_COMMIT}
 
-  app-production:
+  app-production: &production
     build: .
+    environment:
+      - BUILD_HASH=${BUILDKITE_COMMIT}
+
+  app-staging:
+    <<: *production

--- a/docker-compose.buildkite.yml
+++ b/docker-compose.buildkite.yml
@@ -6,8 +6,6 @@ services:
       context: .
       args:
         - NODE_ENV=test
-    environment:
-      - BUILD_HASH=${BUILDKITE_COMMIT}
 
   app-production: &production
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     restart: unless-stopped
     env_file: .env
     environment:
-      NODE_ENV: production
-      POSTGRES_HOST: db
+      - NODE_ENV=production
+      - POSTGRES_HOST=db
     volumes:
       - /opt/app/node_modules
       - ./data:/opt/app/data


### PR DESCRIPTION
This PR makes the CI build steps add environment variable `BUILD_HASH` to the build and sets the environment and release variables on Sentry init.