### PR TITLE
feat: use new RoVer domain in adapter

### DIFF
--- a/src/adapters/rover.ts
+++ b/src/adapters/rover.ts
@@ -3,7 +3,7 @@ import axios from 'axios'
 
 export default async function roVerAdapter (method: Method, pathname: string): Promise<AxiosPromise> {
   return await axios({
-    url: 'https://verify.eryn.io/api/' + pathname,
+    url: 'https://rover.link/api/' + pathname,
     method
   })
 }


### PR DESCRIPTION
RoVer is migrating to a new domain, this PR changes the RoVer adapter to use it.

Blocked until the API has moved to the new domain.