### PR TITLE
fix(Util): remove random space in getOrdinalNum

### DIFF
--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -44,7 +44,7 @@ export function getOrdinalNum (number: number): string {
   } else {
     selector = number % 10
   }
-  return `${number} ${['th', 'st', 'nd', 'rd', ''][selector]}`
+  return `${number}${['th', 'st', 'nd', 'rd', ''][selector]}`
 }
 
 export function makeCommaSeparatedString (array: string[]): string {


### PR DESCRIPTION
Removes the random space in util.getOrdinalNum's return value.