### PR TITLE
fix(RankChangeHandler): fetch roleBindings first

### DIFF
--- a/src/client/websocket/handlers/rank-change.ts
+++ b/src/client/websocket/handlers/rank-change.ts
@@ -17,7 +17,7 @@ export default class RankChangePacketHandler implements BaseHandler {
     const username = (await userService.getUser(userId)).name
     for (const guild of client.guilds.cache.values()) {
       if (guild.robloxGroupId === groupId) {
-        const roleBindings = guild.roleBindings.cache
+        const roleBindings = await guild.roleBindings.fetch()
         if (roleBindings.size > 0) {
           const members = await guild.members.fetch(username) as unknown as Collection<string, GuildMember>
           if (members.size > 0) {


### PR DESCRIPTION
Makes the RankChangePacketHandler fetch the roleBindings before looping over them. Before this, they may have been not initialized yet.