### PR TITLE
fix(Renovate): use replace strategy instead of pin

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
-  "extends": [
-    "config:base"
-  ],
-  "labels": ["dependencies"]
+  "extends": ["config:base"],
+  "labels": ["dependencies"],
+  "rangeStrategy": "replace"
 }


### PR DESCRIPTION
Changes the replace strategy from pinning to replace to have Renovate do the same as Depfu.