### PR TITLE
feat(deps): group Dockerfile and nvm updates and disable npm engine updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,35 @@
 {
-  "extends": ["config:base"],
+  "extends": ["config:base", ":preserveSemverRanges"],
   "labels": ["dependencies"],
-  "rangeStrategy": "replace",
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["engines"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["dockerfile", "nvm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Node.js",
+      "groupSlug": "nodejs"
+    },
+    {
+      "matchManagers": ["dockerfile", "nvm"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "Node.js",
+      "groupSlug": "nodejs"
     }
-  ]
+  ],
+  "buildkite": {
+    "enabled": false
+  },
+  "docker-compose": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
Groups Dockerfile and nvm non-major and major updates and excludes engines.node in package.json from being updated.