### PR TITLE
feat(GuildMemberManager): improve manager to support display names

### DIFF
--- a/src/managers/guild-member.ts
+++ b/src/managers/guild-member.ts
@@ -2,7 +2,7 @@ import { Collection, GuildMemberManager } from 'discord.js'
 import type { FetchMemberOptions, FetchMembersOptions, GuildMember, Snowflake, UserResolvable } from 'discord.js'
 import { userService } from '../services'
 
-const memberNameRegex = (name: string) => new RegExp(`(?:^|\\s*[(])(${name})(?:$|[)]\\s*)`)
+const memberNameRegex = (name: string): RegExp => new RegExp(`(?:^|\\s*[(])(${name})(?:$|[)]\\s*)`)
 
 export default class AroraGuildMemberManager extends GuildMemberManager {
   public override fetch (options: number): Promise<Collection<Snowflake, GuildMember>>

--- a/src/managers/guild-member.ts
+++ b/src/managers/guild-member.ts
@@ -2,7 +2,7 @@ import { Collection, GuildMemberManager } from 'discord.js'
 import type { FetchMemberOptions, FetchMembersOptions, GuildMember, Snowflake, UserResolvable } from 'discord.js'
 import { userService } from '../services'
 
-const memberNameRegex = (name: string): RegExp => new RegExp(`(?:^|\\s*[(])(${name})(?:$|[)]\\s*)`)
+const memberNameRegex = (name: string): RegExp => new RegExp(`^(${name})$|\\s*[(](${name})[)]\\s*`)
 
 export default class AroraGuildMemberManager extends GuildMemberManager {
   public override fetch (options: number): Promise<Collection<Snowflake, GuildMember>>

--- a/src/managers/guild-member.ts
+++ b/src/managers/guild-member.ts
@@ -2,6 +2,8 @@ import { Collection, GuildMemberManager } from 'discord.js'
 import type { FetchMemberOptions, FetchMembersOptions, GuildMember, Snowflake, UserResolvable } from 'discord.js'
 import { userService } from '../services'
 
+const memberNameRegex = (name: string) => new RegExp(`(?:^|\\s*[(])(${name})(?:$|[)]\\s*)`)
+
 export default class AroraGuildMemberManager extends GuildMemberManager {
   public override fetch (options: number): Promise<Collection<Snowflake, GuildMember>>
   public override fetch (
@@ -15,16 +17,16 @@ export default class AroraGuildMemberManager extends GuildMemberManager {
     if (typeof options === 'number') {
       if (this.guild.robloxUsernamesInNicknames) {
         const username = (await userService.getUser(options)).name
-        const usernameRegex = new RegExp(`(?:^|\\s+)(${username})(?:$|\\s+)`)
-        return (await this.fetch()).filter(member => usernameRegex.test(member.displayName))
+        const regex = memberNameRegex(username)
+        return (await this.fetch()).filter(member => regex.test(member.displayName))
       } else {
         return this.cache.filter(member => member.robloxId === options)
       }
     } else if (typeof options === 'string') {
       if (!/^[0-9]+$/.test(options)) {
         if (this.guild.robloxUsernamesInNicknames) {
-          const usernameRegex = new RegExp(`(?:^|\\s+)(${options})(?:$|\\s+)`)
-          return (await this.fetch()).filter(member => usernameRegex.test(member.displayName))
+          const regex = memberNameRegex(options)
+          return (await this.fetch()).filter(member => regex.test(member.displayName))
         } else {
           return new Collection()
         }


### PR DESCRIPTION
Improves the member name regex in the GuildMemberManager that is used in combination with guild setting `robloxUsernamesInNicknames` to fetch a member by Roblox username.

The regex now accepts:
- the exact username
- the username surrounded by parenthesis which may have an arbitrary amount of spaces behind them

Resolves #347 