### PR TITLE
fix: configure Renovate to get unstable Node updates too

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,8 +4,10 @@
   "rangeStrategy": "bump",
   "packageRules": [
     {
+      "matchManagers": ["npm"],
       "matchPackagePatterns": ["*"],
       "matchUpdateTypes": ["minor", "patch"],
+      "excludePackageNames": ["yarn"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"
     },
@@ -16,13 +18,13 @@
     },
     {
       "matchManagers": ["dockerfile", "nvm"],
-      "matchUpdateTypes": ["minor", "patch"],
       "groupName": "Node.js",
-      "groupSlug": "nodejs"
+      "groupSlug": "nodejs",
+      "ignoreUnstable": false
     },
     {
       "matchManagers": ["dockerfile", "nvm"],
-      "matchUpdateTypes": ["major"],
+      "matchUpdateTypes": ["minor", "patch"],
       "groupName": "Node.js",
       "groupSlug": "nodejs"
     }


### PR DESCRIPTION
Configures Renovate to get unstable Node updates too, so that #361 updates `.nvmrc` too.

Also excludes yarn from the non-major dependencies group for the future Yarn 2 update.