### PR TITLE
fix(Client): exclude sourcemaps from being registered

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -99,6 +99,7 @@ jobs:
           environment: ${{ needs.metadata.outputs.stage }}
           finalize: false
           sourcemaps: sourcemaps
+          url_prefix: /opt/app/dist
 
   update_check_run:
     name: Update Check Run

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -33,7 +33,7 @@ const { PartialTypes } = Constants
 const { TYPES } = constants
 const { lazyInject } = getDecorators(container)
 
-const registerFilter = /^(?!base\.js|.*\.d\.).*/
+const registerFilter = /^(?!base\.js|.*\.d\.|.*\.map).*/
 
 const ACTIVITY_CAROUSEL_INTERVAL = 60 * 1000
 


### PR DESCRIPTION
Commando tried to register the sourcemaps using `require-all`, this PR excludes them.

Also a URL prefix is added to the sourcemaps to hopefully fix the errors on Sentry not showing the erroneous files.