### PR TITLE
chore: remove redundant packageRules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,9 +27,6 @@
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "Node.js",
       "groupSlug": "nodejs"
-    },
-    {
-      "matchManagers": ["github-actions"]
     }
   ],
   "docker-compose": {


### PR DESCRIPTION
Removes the github-actions manager's redundant packageRules from the Renovate configuration.