### PR TITLE
fix: sourcemaps uploading and naming

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -99,7 +99,7 @@ jobs:
           environment: ${{ needs.metadata.outputs.stage }}
           finalize: false
           sourcemaps: sourcemaps
-          url_prefix: /opt/app/dist
+          url_prefix: ~/dist
 
   update_check_run:
     name: Update Check Run

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
+    "@sentry/integrations": "^6.15.0",
     "@sentry/node": "^6.15.0",
     "axios": "^0.24.0",
     "class-validator": "^0.13.2",

--- a/src/loaders/index.ts
+++ b/src/loaders/index.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node'
 import { AroraClient } from '../client'
 import type { BaseJob } from '../jobs'
+import { RewriteFrames } from '@sentry/integrations'
 import { constants } from '../util'
 import container from '../configs/container'
 import { createConnection } from 'typeorm'
@@ -14,7 +15,12 @@ export async function init (): Promise<AroraClient> {
     Sentry.init({
       dsn: process.env.SENTRY_DSN,
       environment: process.env.NODE_ENV,
-      release: process.env.BUILD_HASH
+      release: process.env.BUILD_HASH,
+      integrations: [
+        new RewriteFrames({
+          root: process.cwd()
+        })
+      ]
     })
   }
 

--- a/tsconfig.production.json
+++ b/tsconfig.production.json
@@ -1,8 +1,8 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-     "sourceMap": true,                     /* Generates corresponding '.map' file. */
-     "sourceRoot": "src",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-     "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+     "sourceMap": true,                       /* Generates corresponding '.map' file. */
+     "sourceRoot": "src",                     /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+     "inlineSources": true,                   /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
   }
 }

--- a/tsconfig.production.json
+++ b/tsconfig.production.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig",
   "compilerOptions": {
      "sourceMap": true,                     /* Generates corresponding '.map' file. */
-     "sourceRoot": "/",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+     "sourceRoot": "src",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
      "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -304,6 +304,16 @@
     "@sentry/utils" "6.15.0"
     tslib "^1.9.3"
 
+"@sentry/integrations@^6.15.0":
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-6.15.0.tgz#3c83617c301b5f77a57514ad7812aedc03613a31"
+  integrity sha512-fSBAipas6zwyYo4U91pyQOnaTcRCfwvH6ZFwu0Fqmkm64nU9rYpbTNiKkwOWbbiXXT6+LEF6RzBpsyhm4QvgmQ==
+  dependencies:
+    "@sentry/types" "6.15.0"
+    "@sentry/utils" "6.15.0"
+    localforage "^1.8.1"
+    tslib "^1.9.3"
+
 "@sentry/minimal@6.15.0":
   version "6.15.0"
   resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.15.0.tgz#fcc083ba901cfe57d25303d0b5fa8cd13e164466"
@@ -1552,6 +1562,11 @@ ignore@^5.1.1, ignore@^5.1.4, ignore@^5.1.8:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
+
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
@@ -1802,10 +1817,24 @@ libphonenumber-js@^1.9.43:
   resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.9.43.tgz#2371e4383e6780990381d5b900b8c22666221cbb"
   integrity sha512-tNB87ZutAiAkl3DE/Bo0Mxqn/XZbNxhPg4v9bYBwQQW4dlhBGqXl1vtmPxeDWbrijzwOA9vRjOOFm5V9SK/W3w==
 
+lie@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
+  integrity sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=
+  dependencies:
+    immediate "~3.0.5"
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
+
+localforage@^1.8.1:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.10.0.tgz#5c465dc5f62b2807c3a84c0c6a1b1b3212781dd4"
+  integrity sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==
+  dependencies:
+    lie "3.1.1"
 
 locate-path@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
After a lot of local testing last night (should've done that before the GH Actions PR), these changes seem to work and make Sentry show the correct files and paths.

The RewriteFrames plugin takes frames of the stack and removes a root (in this case `/opt/app`) from it, so the resulting frame would be `dist/...`, which can then be coupled to the sourcemaps that now also start with `~/dist`.
The sourceRoot in `tsconfig.production.json` was changed to `src` so that Sentry shows for example `src/index.ts` instead of `/index.ts`, which is more correct imo. With this, linking stack traces to source code can now also work (I linked `src/` to `src/`).