### PR TITLE
fix: remove node_modules from volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,6 @@ services:
     environment:
       - POSTGRES_HOST=db
     volumes:
-      - /opt/app/node_modules
-      - ./data:/opt/app/data
       - ./config/application.js:/opt/app/config/application.js
     command: /bin/bash ./bin/wait-for-it.sh db:5432 -- yarn start
 


### PR DESCRIPTION
Fixes the bug where deploys do not get updated node_modules until they are stopped and restarted.