### PR TITLE
fix: set correct Sentry version when after merge and pass correct build hash

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -162,6 +162,7 @@ jobs:
           SENTRY_PROJECT: ${{ env.PROJECT_NAME }}
         with:
           environment: ${{ needs.metadata.outputs.stage }}
+          version: ${{ needs.merge.outputs.sha }}
           set_commits: skip
 
       - name: Finish deployment

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -40,12 +40,8 @@ jobs:
             BUILD_ARGS='BUILD_HASH='$GITHUB_SHA
             if [ $GITHUB_REF_NAME = 'main' ]; then
               BUILD_ARGS+=$'\nNODE_ENV=production'
-
-              echo '::set-output name=stage::production'
             else
               BUILD_ARGS+=$'\nNODE_ENV=staging'
-
-              echo '::set-output name=stage::staging'
             fi
             BUILD_ARGS=${BUILD_ARGS//$'\n'/'%0A'}
             echo '::set-output name=build_args::'$BUILD_ARGS
@@ -99,9 +95,9 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_PROJECT: ${{ env.PROJECT_NAME }}
         with:
-          environment: ${{ needs.metadata.outputs.stage }}
           finalize: false
           sourcemaps: sourcemaps
+          version: ${{ inputs.sha }}
           url_prefix: ~/dist
 
   update_check_run:

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Get metadata
         id: get_metadata
+        env:
+          INPUT_SHA: ${{ inputs.sha }}
         run: |
           if [ $GITHUB_REF_NAME = 'main' ]; then
             echo '::set-output name=tag::latest'
@@ -37,7 +39,7 @@ jobs:
           fi
 
           if [ $GITHUB_REF_NAME = 'staging' ] || [ $GITHUB_REF_NAME = 'main' ]; then
-            BUILD_ARGS='BUILD_HASH='$GITHUB_SHA
+            BUILD_ARGS='BUILD_HASH='${INPUT_SHA:-GITHUB_SHA}
             if [ $GITHUB_REF_NAME = 'main' ]; then
               BUILD_ARGS+=$'\nNODE_ENV=production'
             else


### PR DESCRIPTION
- Sets version in Publish Image and Continuous Delivery explicitly when it is either from a merge commit or the workflow was triggered via `workflow_call`.
- Removes environment from the Sentry release action in Publish Image to not [create a deployment](getsentry/action-release@744e4b2/src/main.ts#L56). 
- Passes the correct build hash to the build for Sentry to use and fixes another place where inputs were read from the wrong context.