### PR TITLE
fix(WebSocketManager): support WS_HOST env variable

### DIFF
--- a/src/client/websocket/websocket.ts
+++ b/src/client/websocket/websocket.ts
@@ -23,7 +23,7 @@ export default class WebSocketManager {
   private pingTimeout: NodeJS.Timeout | null
 
   public constructor () {
-    this.host = 'ws://127.0.0.1'
+    this.host = process.env.WS_HOST ?? 'ws://127.0.0.1'
     this.connection = null
     this.pingTimeout = null
   }


### PR DESCRIPTION
#353 accidentally (or at least I don't remember a reason) removed this.