### PR TITLE
fix(BansCommand): defer reply when listing all bans

### DIFF
--- a/src/interactions/application-commands/slash-commands/admin/bans.ts
+++ b/src/interactions/application-commands/slash-commands/admin/bans.ts
@@ -207,6 +207,8 @@ export default class BansCommand extends SubCommandCommand<BansCommand> {
 
       return await interaction.reply({ embeds: [embed] })
     } else {
+      await interaction.deferReply()
+
       const bans = (await applicationAdapter('GET', `v1/groups/${context.robloxGroupId}/bans?sort=date`)).data
       if (bans.length === 0) {
         return await interaction.reply('There are currently no bans.')


### PR DESCRIPTION
Hopefully resolves #434. If this bug occurs on other commands in the future, this fix should be applied there too.