### PR TITLE
fix(CD): don't run double migrations on production

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -154,7 +154,6 @@ jobs:
             if [ "$STAGE" = 'production' ]; then
               docker-compose run --rm nsadmin yarn run typeorm migration:run
               docker-compose run --rm nsadmin node bin/update-commands.js
-              docker-compose run --rm tradmin yarn run typeorm migration:run
               docker-compose run --rm tradmin node bin/update-commands.js
             else
               docker-compose run --rm app yarn run typeorm migration:run


### PR DESCRIPTION
Both services connect to the same database, so running migrations in only one of them is sufficient.