### PR TITLE
fix: pin actionlint to v1.6.13

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Download actionlint
         run: |
-          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.6.13
 
       - name: Load test image
         uses: guidojw/actions/load-docker-image@5faa9418b42a6a77f81e11ae935287900673f98b # tag=v1.3.2
@@ -57,6 +57,7 @@ jobs:
       - name: Lint
         run: |
           EXIT_STATUS=0
-          ./actionlint -ignore 'property "app_private_key" is not defined' -ignore 'SC2153:' || EXIT_STATUS=$?
+          ./actionlint -ignore 'property "app_private_key" is not defined' -ignore 'SC2153:' \
+            -ignore 'property "sha" is not defined in object type {}' || EXIT_STATUS=$?
           docker run app yarn lint || EXIT_STATUS=$?
           exit $EXIT_STATUS


### PR DESCRIPTION
Pins actionlint's version so that bugs in new actionlint versions do not fail builds on this project.