### PR TITLE
refactor: update set-output commands to use GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -48,15 +48,15 @@ jobs:
             if [ "${INPUT_MERGE,,}" = 'y' ]; then
               git fetch origin staging
               if ! git diff origin/main origin/staging --exit-code; then
-                echo '::set-output name=has_diff::true'
+                echo 'has_diff=true' >> "$GITHUB_OUTPUT"
               else
-                echo '::set-output name=has_diff::false'
+                echo 'has_diff=false' >> "$GITHUB_OUTPUT"
               fi
             fi
 
-            echo '::set-output name=stage::production'
+            echo 'stage=production' >> "$GITHUB_OUTPUT"
           else
-            echo '::set-output name=stage::staging'
+            echo 'stage=staging' >> "$GITHUB_OUTPUT"
           fi
 
   merge:
@@ -98,7 +98,7 @@ jobs:
         if: fromJSON(needs.metadata.outputs.has_diff)
         run: |
           git fetch origin main
-          echo '::set-output name=sha::'"$(git rev-parse origin/main)"
+          echo 'sha='"$(git rev-parse origin/main)" >> "$GITHUB_OUTPUT"
 
   continuous_integration:
     name: Continuous Integration
@@ -191,10 +191,10 @@ jobs:
         env:
           RESULTS: ${{ join(needs.*.result, ' ') }}
         run: |
-          echo '::set-output name=conclusion::success'
+          echo 'conclusion=success' >> "$GITHUB_OUTPUT"
           for RESULT in $RESULTS; do
             if [ "$RESULT" = 'cancelled' ] || [ "$RESULT" = 'failure' ]; then
-              echo '::set-output name=conclusion::'"$RESULT"
+              echo 'conclusion='"$RESULT" >> "$GITHUB_OUTPUT"
               break
             fi
           done

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -47,8 +47,9 @@ jobs:
             else
               BUILD_ARGS+=$'\nNODE_ENV=staging'
             fi
-            BUILD_ARGS=${BUILD_ARGS//$'\n'/'%0A'}
-            echo '::set-output name=build_args::'"$BUILD_ARGS"
+            echo 'build_args<<EOF' >> "$GITHUB_OUTPUT"
+            echo "$BUILD_ARGS" >> "$GITHUB_OUTPUT"
+            echo 'EOF' >> "$GITHUB_OUTPUT"
           fi
 
   publish:
@@ -115,10 +116,10 @@ jobs:
         env:
           RESULTS: ${{ join(needs.*.result, ' ') }}
         run: |
-          echo '::set-output name=conclusion::success'
+          echo 'conclusion=success' >> "$GITHUB_OUTPUT"
           for RESULT in $RESULTS; do
             if [ "$RESULT" = 'cancelled' ] || [ "$RESULT" = 'failure' ]; then
-              echo '::set-output name=conclusion::'"$RESULT"
+              echo 'conclusion='"$RESULT" >> "$GITHUB_OUTPUT"
               break
             fi
           done

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -35,9 +35,9 @@ jobs:
           INPUT_SHA: ${{ inputs.sha }}
         run: |
           if [ "$GITHUB_REF_NAME" = 'main' ]; then
-            echo '::set-output name=tag::latest'
+            echo 'tag=latest'
           else
-            echo '::set-output name=tag::'"$GITHUB_REF_NAME"
+            echo 'tag='"$GITHUB_REF_NAME"
           fi
 
           if [ "$GITHUB_REF_NAME" = 'staging' ] || [ "$GITHUB_REF_NAME" = 'main' ]; then

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -47,9 +47,11 @@ jobs:
             else
               BUILD_ARGS+=$'\nNODE_ENV=staging'
             fi
-            echo 'build_args<<EOF' >> "$GITHUB_OUTPUT"
-            echo "$BUILD_ARGS" >> "$GITHUB_OUTPUT"
-            echo 'EOF' >> "$GITHUB_OUTPUT"
+            {
+              echo 'build_args<<EOF'
+              echo "$BUILD_ARGS"
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
           fi
 
   publish:


### PR DESCRIPTION
`::set-output::` is deprecated and will be disabled next year.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/