### PR TITLE
fix: empty trainings notes passed as null instead of undefined

### DIFF
--- a/src/interactions/application-commands/slash-commands/admin/trainings.ts
+++ b/src/interactions/application-commands/slash-commands/admin/trainings.ts
@@ -64,7 +64,7 @@ export default class TrainingsCommand extends SubCommandCommand<TrainingsCommand
       type: string
       date: string
       time: string
-      notes?: string
+      notes: string | null
     }
   ): Promise<void> {
     const context = this.guildContexts.resolve(interaction.guildId) as GuildContext & { robloxGroupId: number }
@@ -102,7 +102,7 @@ export default class TrainingsCommand extends SubCommandCommand<TrainingsCommand
     const training = (await applicationAdapter('POST', `v1/groups/${context.robloxGroupId}/trainings`, {
       authorId,
       date: dateUnix,
-      notes,
+      notes: notes ?? undefined,
       typeId: trainingType.id
     })).data
 


### PR DESCRIPTION
Empty notes were passed as `null` instead of `undefined`, something the backend does not accept and therefore throws a 422 Unprocessed error. This fixes that and allows the usage of `/trainings schedule` with no notes specified again.