### PR TITLE
fix: defer promote/demote interaction reply

### DIFF
--- a/src/interactions/application-commands/slash-commands/admin/demote.ts
+++ b/src/interactions/application-commands/slash-commands/admin/demote.ts
@@ -43,10 +43,12 @@ export default class DemoteCommand extends Command {
       })
     }
 
+    await interaction.deferReply()
+
     const roles: ChangeMemberRole = (await applicationAdapter('POST', `v1/groups/${context.robloxGroupId}/users/${user.id}/demote`, {
       authorId
     })).data
 
-    return await interaction.reply(`Successfully demoted **${user.username ?? user.id}** from **${roles.oldRole.name}** to **${roles.newRole.name}**.`)
+    await interaction.editReply(`Successfully demoted **${user.username ?? user.id}** from **${roles.oldRole.name}** to **${roles.newRole.name}**.`)
   }
 }

--- a/src/interactions/application-commands/slash-commands/admin/promote.ts
+++ b/src/interactions/application-commands/slash-commands/admin/promote.ts
@@ -43,10 +43,12 @@ export default class PromoteCommand extends Command {
       })
     }
 
+    await interaction.deferReply()
+
     const roles: ChangeMemberRole = (await applicationAdapter('POST', `v1/groups/${context.robloxGroupId}/users/${user.id}/promote`, {
       authorId
     })).data
 
-    return await interaction.reply(`Successfully promoted **${user.username ?? user.id}** from **${roles.oldRole.name}** to **${roles.newRole.name}**.`)
+    await interaction.editReply(`Successfully promoted **${user.username ?? user.id}** from **${roles.oldRole.name}** to **${roles.newRole.name}**.`)
   }
 }


### PR DESCRIPTION
Defers the reply for the `/promote` and `/demote` interactions as they are more likely to take more than 3s (happened a few times before).