### PR TITLE
fix: explicitly specify all class-validator validations

### DIFF
--- a/src/entities/channel.ts
+++ b/src/entities/channel.ts
@@ -9,6 +9,7 @@ import {
   OneToOne,
   PrimaryColumn
 } from 'typeorm'
+import { IsNumberString, IsOptional, ValidateIf, ValidateNested } from 'class-validator'
 import Group from './group'
 import Guild from './guild'
 import Message from './message'
@@ -17,16 +18,22 @@ import Ticket from './ticket'
 @Entity('channels')
 export default class Channel {
   @PrimaryColumn({ type: 'bigint' })
+  @IsNumberString({ no_symbols: true })
   public id!: string
 
   @Column('bigint', { name: 'guild_id' })
+  @IsNumberString({ no_symbols: true })
   public guildId!: string
 
   @ManyToOne(() => Guild, guild => guild.channels, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'guild_id' })
+  @ValidateIf(channel => typeof channel.guild !== 'undefined')
+  @ValidateNested()
   public guild?: Guild
 
   @ManyToMany(() => Group, group => group.channels)
+  @ValidateIf(channel => typeof channel.groups !== 'undefined')
+  @ValidateNested()
   public groups?: Group[]
 
   @ManyToMany(() => Channel, channel => channel.fromLinks, { cascade: true })
@@ -35,14 +42,22 @@ export default class Channel {
     joinColumn: { name: 'from_channel_id' },
     inverseJoinColumn: { name: 'to_channel_id' }
   })
+  @ValidateIf(channel => typeof channel.toLinks !== 'undefined')
+  @ValidateNested()
   public toLinks?: Channel[]
 
   @ManyToMany(() => Channel, channel => channel.toLinks)
+  @ValidateIf(channel => typeof channel.fromLinks !== 'undefined')
+  @ValidateNested()
   public fromLinks?: Channel[]
 
   @OneToMany(() => Message, message => message.channel)
+  @ValidateIf(channel => typeof channel.messages !== 'undefined')
+  @ValidateNested()
   public messages?: Message[]
 
   @OneToOne(() => Ticket, ticket => ticket.channel)
+  @IsOptional()
+  @ValidateNested()
   public ticket?: Ticket | null
 }

--- a/src/entities/emoji.ts
+++ b/src/entities/emoji.ts
@@ -1,19 +1,26 @@
 import { Column, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryColumn } from 'typeorm'
+import { IsNumberString, ValidateIf, ValidateNested } from 'class-validator'
 import Guild from './guild'
 import RoleMessage from './role-message'
 
 @Entity('emojis')
 export default class Emoji {
   @PrimaryColumn({ type: 'bigint' })
+  @IsNumberString({ no_symbols: true })
   public id!: string
 
   @Column('bigint', { name: 'guild_id' })
+  @IsNumberString({ no_symbols: true })
   public guildId!: string
 
   @ManyToOne(() => Guild, guild => guild.emojis, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'guild_id' })
+  @ValidateIf(emoji => typeof emoji.guild !== 'undefined')
+  @ValidateNested()
   public guild?: Guild
 
   @OneToMany(() => RoleMessage, roleMessage => roleMessage.emoji)
+  @ValidateIf(emoji => typeof emoji.roleMessages !== 'undefined')
+  @ValidateNested()
   public roleMessages?: RoleMessage[]
 }

--- a/src/entities/group.ts
+++ b/src/entities/group.ts
@@ -1,30 +1,49 @@
 import { Column, Entity, JoinColumn, JoinTable, ManyToMany, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
+import {
+  IsBoolean,
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsNumberString,
+  IsString,
+  MaxLength,
+  ValidateIf,
+  ValidateNested
+} from 'class-validator'
 import Channel from './channel'
 import { GroupType } from '../utils/constants'
 import Guild from './guild'
-import { IsNotEmpty } from 'class-validator'
 import Role from './role'
 
 @Entity('groups')
 export default class Group {
   @PrimaryGeneratedColumn()
+  @ValidateIf(group => typeof group.id !== 'undefined')
+  @IsNumber({ maxDecimalPlaces: 0 })
   public readonly id!: number
 
   @Column({ length: 255 })
+  @IsString()
   @IsNotEmpty()
+  @MaxLength(255)
   public name!: string
 
   @Column({ type: 'enum', enum: GroupType })
+  @IsEnum(GroupType)
   public type!: GroupType
 
   @Column({ default: false })
+  @IsBoolean()
   public guarded!: boolean
 
   @Column('bigint', { name: 'guild_id' })
+  @IsNumberString({ no_symbols: true })
   public guildId!: string
 
   @ManyToOne(() => Guild, guild => guild.groups, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'guild_id' })
+  @ValidateIf(group => typeof group.guild !== 'undefined')
+  @ValidateNested()
   public guild?: Guild
 
   @ManyToMany(() => Channel, channel => channel.groups, { cascade: true })
@@ -33,6 +52,8 @@ export default class Group {
     joinColumn: { name: 'group_id' },
     inverseJoinColumn: { name: 'channel_id' }
   })
+  @ValidateIf(group => typeof group.channels !== 'undefined')
+  @ValidateNested()
   public channels?: Channel[]
 
   @ManyToMany(() => Role, role => role.groups, { cascade: true })
@@ -41,5 +62,7 @@ export default class Group {
     joinColumn: { name: 'group_id' },
     inverseJoinColumn: { name: 'role_id' }
   })
+  @ValidateIf(group => typeof group.roles !== 'undefined')
+  @ValidateNested()
   public roles?: Role[]
 }

--- a/src/entities/guild.ts
+++ b/src/entities/guild.ts
@@ -1,4 +1,13 @@
 import { Column, Entity, JoinColumn, OneToMany, OneToOne, PrimaryColumn } from 'typeorm'
+import {
+  IsArray,
+  IsBoolean,
+  IsEnum, IsNumber,
+  IsNumberString,
+  IsOptional,
+  ValidateIf,
+  ValidateNested
+} from 'class-validator'
 import Channel from './channel'
 import Emoji from './emoji'
 import Group from './group'
@@ -16,18 +25,25 @@ import { VerificationProvider } from '../utils/constants'
 @Entity('guilds')
 export default class Guild {
   @PrimaryColumn({ type: 'bigint' })
+  @IsNumberString({ no_symbols: true })
   public id!: string
 
   @Column('int', { name: 'primary_color', nullable: true })
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 0 })
   public primaryColor?: number | null
 
   @Column('int', { name: 'roblox_group_id', nullable: true })
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 0 })
   public robloxGroupId?: number | null
 
   @Column({ name: 'roblox_usernames_in_nicknames', default: false })
+  @IsBoolean()
   public robloxUsernamesInNicknames!: boolean
 
   @Column({ name: 'support_enabled', default: false })
+  @IsBoolean()
   public supportEnabled!: boolean
 
   @Column({
@@ -36,76 +52,133 @@ export default class Guild {
     enum: VerificationProvider,
     default: VerificationProvider.RoVer
   })
+  @IsEnum(VerificationProvider)
   public verificationPreference!: VerificationProvider
 
   @Column('bigint', { name: 'logs_channel_id', nullable: true })
+  @IsOptional()
+  @IsNumberString({ no_symbols: true })
   public logsChannelId?: string | null
 
   @Column('bigint', { name: 'suggestions_channel_id', nullable: true })
+  @IsOptional()
+  @IsNumberString({ no_symbols: true })
   public suggestionsChannelId?: string | null
 
   @Column('bigint', { name: 'ratings_channel_id', nullable: true })
+  @IsOptional()
+  @IsNumberString({ no_symbols: true })
   public ratingsChannelId?: string | null
 
   @Column('bigint', { name: 'ticket_archives_channel_id', nullable: true })
+  @IsOptional()
+  @IsNumberString({ no_symbols: true })
   public ticketArchivesChannelId?: string | null
 
   @Column('bigint', { name: 'tickets_category_id', nullable: true })
+  @IsOptional()
+  @IsNumberString({ no_symbols: true })
   public ticketsCategoryId?: string | null
 
   @OneToMany(() => Tag, tag => tag.guild)
+  @ValidateIf(guild => typeof guild.tags !== 'undefined')
+  @ValidateNested()
+  @IsArray()
   public tags?: Tag[]
 
   @OneToMany(() => Ticket, ticket => ticket.guild)
+  @ValidateIf(guild => typeof guild.tickets !== 'undefined')
+  @ValidateNested()
+  @IsArray()
   public tickets?: Ticket[]
 
   @OneToMany(() => RoleBinding, roleBinding => roleBinding.guild)
+  @ValidateIf(guild => typeof guild.roleBindings !== 'undefined')
+  @ValidateNested()
+  @IsArray()
   public roleBindings?: RoleBinding[]
 
   @OneToMany(() => RoleMessage, roleMessage => roleMessage.guild)
+  @ValidateIf(guild => typeof guild.roleMessages !== 'undefined')
+  @ValidateNested()
+  @IsArray()
   public roleMessages?: RoleMessage[]
 
   @OneToMany(() => Group, group => group.guild)
+  @ValidateIf(guild => typeof guild.groups !== 'undefined')
+  @ValidateNested()
+  @IsArray()
   public groups?: Group[]
 
   @OneToMany(() => Role, role => role.guild)
+  @ValidateIf(guild => typeof guild.roles !== 'undefined')
+  @ValidateNested()
+  @IsArray()
   public roles?: Role[]
 
   @OneToMany(() => Panel, panel => panel.guild)
+  @ValidateIf(guild => typeof guild.panels !== 'undefined')
+  @ValidateNested()
+  @IsArray()
   public panels?: Panel[]
 
   @OneToMany(() => Channel, channel => channel.guild)
+  @ValidateIf(guild => typeof guild.channels !== 'undefined')
+  @ValidateNested()
+  @IsArray()
   public channels?: Channel[]
 
   @OneToOne(() => Channel, { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'logs_channel_id' })
+  @IsOptional()
+  @ValidateNested()
   public logsChannel?: Channel | null
 
   @OneToOne(() => Channel, { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'suggestions_channel_id' })
+  @IsOptional()
+  @ValidateNested()
   public suggestionsChannel?: Channel | null
 
   @OneToOne(() => Channel, { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'ratings_channel_id' })
+  @IsOptional()
+  @ValidateNested()
   public ratingsChannel?: Channel | null
 
   @OneToOne(() => Channel, { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'ticket_archives_channel_id' })
+  @IsOptional()
+  @ValidateNested()
   public ticketArchivesChannel?: Channel | null
 
   @OneToOne(() => Channel, { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'tickets_category_id' })
+  @IsOptional()
+  @ValidateNested()
   public ticketsCategory?: Channel | null
 
   @OneToMany(() => TicketType, ticketType => ticketType.guild)
+  @ValidateIf(guild => typeof guild.ticketTypes !== 'undefined')
+  @ValidateNested()
+  @IsArray()
   public ticketTypes?: TicketType[]
 
   @OneToMany(() => Emoji, emoji => emoji.guild)
+  @ValidateIf(guild => typeof guild.emojis !== 'undefined')
+  @ValidateNested()
+  @IsArray()
   public emojis?: Emoji[]
 
   @OneToMany(() => Message, message => message.guild)
+  @ValidateIf(guild => typeof guild.messages !== 'undefined')
+  @ValidateNested()
+  @IsArray()
   public messages?: Message[]
 
   @OneToMany(() => Member, member => member.guild)
+  @ValidateIf(guild => typeof guild.members !== 'undefined')
+  @ValidateNested()
+  @IsArray()
   public members?: Member[]
 }

--- a/src/entities/member.ts
+++ b/src/entities/member.ts
@@ -8,6 +8,7 @@ import {
   OneToMany,
   PrimaryGeneratedColumn
 } from 'typeorm'
+import { IsNumber, IsNumberString, ValidateIf, ValidateNested } from 'class-validator'
 import Guild from './guild'
 import Role from './role'
 import Ticket from './ticket'
@@ -15,19 +16,27 @@ import Ticket from './ticket'
 @Entity('members')
 export default class Member {
   @PrimaryGeneratedColumn()
+  @ValidateIf(member => typeof member.id !== 'undefined')
+  @IsNumber({ maxDecimalPlaces: 0 })
   public readonly id!: number
 
   @Column('bigint', { name: 'user_id' })
+  @IsNumberString({ no_symbols: true })
   public userId!: string
 
   @Column('bigint', { name: 'guild_id' })
+  @IsNumberString({ no_symbols: true })
   public guildId!: string
 
   @ManyToOne(() => Guild, guild => guild.members, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'guild_id' })
+  @ValidateIf(member => typeof member.guild !== 'undefined')
+  @ValidateNested()
   public guild?: Guild
 
   @OneToMany(() => Ticket, ticket => ticket.author)
+  @ValidateIf(member => typeof member.tickets !== 'undefined')
+  @ValidateNested()
   public tickets?: Ticket[]
 
   @ManyToMany(() => Ticket, ticket => ticket.moderators, { cascade: true })
@@ -36,6 +45,8 @@ export default class Member {
     joinColumn: { name: 'member_id' },
     inverseJoinColumn: { name: 'ticket_id' }
   })
+  @ValidateIf(member => typeof member.moderatingTickets !== 'undefined')
+  @ValidateNested()
   public moderatingTickets?: Ticket[]
 
   @ManyToMany(() => Role, role => role.members, { cascade: true })
@@ -44,5 +55,7 @@ export default class Member {
     joinColumn: { name: 'member_id' },
     inverseJoinColumn: { name: 'role_id' }
   })
+  @ValidateIf(member => typeof member.roles !== 'undefined')
+  @ValidateNested()
   public roles?: Role[]
 }

--- a/src/entities/message.ts
+++ b/src/entities/message.ts
@@ -1,4 +1,5 @@
 import { Column, Entity, JoinColumn, ManyToOne, OneToMany, OneToOne, PrimaryColumn } from 'typeorm'
+import { IsNumberString, IsOptional, ValidateIf, ValidateNested } from 'class-validator'
 import Channel from './channel'
 import Guild from './guild'
 import Panel from './panel'
@@ -8,28 +9,41 @@ import TicketType from './ticket-type'
 @Entity('messages')
 export default class Message {
   @PrimaryColumn({ type: 'bigint' })
+  @IsNumberString({ no_symbols: true })
   public id!: string
 
   @Column('bigint', { name: 'guild_id' })
+  @IsNumberString({ no_symbols: true })
   public guildId!: string
 
   @Column('bigint', { name: 'channel_id' })
+  @IsNumberString({ no_symbols: true })
   public channelId!: string
 
   @ManyToOne(() => Guild, guild => guild.messages, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'guild_id' })
+  @ValidateIf(message => typeof message.guild !== 'undefined')
+  @ValidateNested()
   public guild?: Guild
 
   @ManyToOne(() => Channel, channel => channel.messages, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'channel_id' })
+  @ValidateIf(message => typeof message.channel !== 'undefined')
+  @ValidateNested()
   public channel?: Channel
 
   @OneToOne(() => Panel, panel => panel.message)
+  @IsOptional()
+  @ValidateNested()
   public panel?: Panel | null
 
   @OneToOne(() => TicketType, ticketType => ticketType.message)
+  @IsOptional()
+  @ValidateNested()
   public ticketType?: TicketType | null
 
   @OneToMany(() => RoleMessage, roleMessage => roleMessage.message)
+  @ValidateIf(message => typeof message.roleMessages !== 'undefined')
+  @ValidateNested()
   public roleMessages?: RoleMessage[]
 }

--- a/src/entities/panel.ts
+++ b/src/entities/panel.ts
@@ -1,29 +1,43 @@
 import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
+import { IsNumber, IsNumberString, IsOptional, IsString, MaxLength, ValidateIf, ValidateNested } from 'class-validator'
 import Guild from './guild'
 import Message from './message'
 
 @Entity('panels')
 export default class Panel {
   @PrimaryGeneratedColumn()
+  @ValidateIf(panel => typeof panel.id !== 'undefined')
+  @IsNumber({ maxDecimalPlaces: 0 })
   public readonly id!: number
 
   @Column({ length: 255 })
+  @IsString()
+  @MaxLength(255)
   public name!: string
 
   @Column({ length: 7000 })
+  @IsString()
+  @MaxLength(7000)
   public content!: string
 
   @Column('bigint', { name: 'guild_id' })
+  @IsNumberString({ no_symbols: true })
   public guildId!: string
 
   @Column('bigint', { name: 'message_id', nullable: true, unique: true })
+  @IsOptional()
+  @IsString()
   public messageId?: string | null
 
   @ManyToOne(() => Guild, guild => guild.panels, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'guild_id' })
+  @ValidateIf(panel => typeof panel.guild !== 'undefined')
+  @ValidateNested()
   public guild?: Guild
 
   @ManyToOne(() => Message, message => message.panel, { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'message_id' })
+  @IsOptional()
+  @ValidateNested()
   public message?: Message | null
 }

--- a/src/entities/role-binding.ts
+++ b/src/entities/role-binding.ts
@@ -1,32 +1,45 @@
 import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
+import { IsNumber, IsNumberString, IsOptional, ValidateIf, ValidateNested } from 'class-validator'
 import Guild from './guild'
 import Role from './role'
 
 @Entity('role_bindings')
 export default class RoleBinding {
   @PrimaryGeneratedColumn()
+  @ValidateIf(roleBinding => typeof roleBinding.id !== 'undefined')
+  @IsNumber({ maxDecimalPlaces: 0 })
   public readonly id!: number
 
   @Column({ name: 'roblox_group_id' })
+  @IsNumber({ maxDecimalPlaces: 0 })
   public robloxGroupId!: number
 
   @Column()
+  @IsNumber({ maxDecimalPlaces: 0 })
   public min!: number
 
   @Column('int', { nullable: true })
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 0 })
   public max?: number | null
 
   @Column('bigint', { name: 'guild_id' })
+  @IsNumberString({ no_symbols: true })
   public guildId!: string
 
   @Column('bigint', { name: 'role_id' })
+  @IsNumberString({ no_symbols: true })
   public roleId!: string
 
   @ManyToOne(() => Guild, guild => guild.roleBindings, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'guild_id' })
+  @ValidateIf(roleBinding => typeof roleBinding.guild !== 'undefined')
+  @ValidateNested()
   public guild?: Guild
 
   @ManyToOne(() => Role, role => role.roleBindings, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'role_id' })
+  @ValidateIf(roleBinding => typeof roleBinding.role !== 'undefined')
+  @ValidateNested()
   public role?: Role
 }

--- a/src/entities/role-message.ts
+++ b/src/entities/role-message.ts
@@ -1,5 +1,5 @@
 import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
-import { IsNotEmpty, ValidateIf } from 'class-validator'
+import { IsNotEmpty, IsNumber, IsNumberString, IsOptional, IsString, ValidateIf, ValidateNested } from 'class-validator'
 // import Emoji from './emoji'
 import Guild from './guild'
 import Message from './message'
@@ -11,42 +11,59 @@ const { Xor } = decorators
 @Entity('role_messages')
 export default class RoleMessage {
   @PrimaryGeneratedColumn()
+  @ValidateIf(roleMessage => typeof roleMessage.id !== 'undefined')
+  @IsNumber({ maxDecimalPlaces: 0 })
   public readonly id!: number
 
   @Column('varchar', { length: 7, nullable: true })
-  @ValidateIf(roleMessage => roleMessage.emoji != null)
-  @Xor('emojiId')
+  @IsOptional()
+  @IsString()
   @IsNotEmpty()
+  @Xor('emojiId')
   public emoji?: string | null
 
   @Column('bigint', { name: 'guild_id' })
+  @IsNumberString({ no_symbols: true })
   public guildId!: string
 
   @Column('bigint', { name: 'emoji_id', nullable: true })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
   @Xor('emoji')
   public emojiId?: string | null
 
   @Column('bigint', { name: 'role_id' })
+  @IsNumberString({ no_symbols: true })
   public roleId!: string
 
   @Column('bigint', { name: 'message_id' })
+  @IsNumberString({ no_symbols: true })
   public messageId!: string
 
   @ManyToOne(() => Guild, guild => guild.roleMessages, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'guild_id' })
+  @ValidateIf(roleMessage => typeof roleMessage.guild !== 'undefined')
+  @ValidateNested()
   public guild?: Guild
 
   /* eslint-disable max-len */
   // @ManyToOne(() => Emoji, emoji => emoji.roleMessages, { onDelete: 'CASCADE' })
   // @JoinColumn({ name: 'emoji_id' })
+  // @IsOptional()
+  // @ValidateNested()
   // public emoji?: Emoji | null
   /* eslint-enable max-len */
 
   @ManyToOne(() => Role, role => role.roleMessages, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'role_id' })
+  @ValidateIf(roleMessage => typeof roleMessage.role !== 'undefined')
+  @ValidateNested()
   public role?: Role
 
   @ManyToOne(() => Message, message => message.roleMessages, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'message_id' })
+  @IsOptional()
+  @ValidateNested()
   public message?: Message | null
 }

--- a/src/entities/role.ts
+++ b/src/entities/role.ts
@@ -1,4 +1,5 @@
 import { Column, Entity, JoinColumn, ManyToMany, ManyToOne, OneToMany, PrimaryColumn } from 'typeorm'
+import { IsNumberString, ValidateIf, ValidateNested } from 'class-validator'
 import Group from './group'
 import Guild from './guild'
 import Member from './member'
@@ -8,24 +9,36 @@ import RoleMessage from './role-message'
 @Entity('roles')
 export default class Role {
   @PrimaryColumn({ type: 'bigint' })
+  @IsNumberString({ no_symbols: true })
   public id!: string
 
   @Column('bigint', { name: 'guild_id' })
+  @IsNumberString({ no_symbols: true })
   public guildId!: string
 
   @ManyToOne(() => Guild, guild => guild.roles, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'guild_id' })
+  @ValidateIf(role => typeof role.guild !== 'undefined')
+  @ValidateNested()
   public guild?: Guild
 
   @ManyToMany(() => Group, group => group.roles)
+  @ValidateIf(role => typeof role.groups !== 'undefined')
+  @ValidateNested()
   public groups?: Group[]
 
   @OneToMany(() => RoleMessage, roleMessage => roleMessage.role)
+  @ValidateIf(role => typeof role.roleMessages !== 'undefined')
+  @ValidateNested()
   public roleMessages?: RoleMessage[]
 
   @OneToMany(() => RoleBinding, roleBinding => roleBinding.role)
+  @ValidateIf(role => typeof role.roleBindings !== 'undefined')
+  @ValidateNested()
   public roleBindings?: RoleBinding[]
 
   @ManyToMany(() => Member, member => member.roles)
+  @ValidateIf(role => typeof role.members !== 'undefined')
+  @ValidateNested()
   public members?: Member[]
 }

--- a/src/entities/tag-name.ts
+++ b/src/entities/tag-name.ts
@@ -1,19 +1,24 @@
 import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm'
-import { IsLowercase, IsNotEmpty } from 'class-validator'
+import { IsLowercase, IsNotEmpty, IsNumber, IsString, MaxLength, ValidateIf, ValidateNested } from 'class-validator'
 import Tag from './tag'
 
 @Entity('tag_names')
 export default class TagName {
   @PrimaryColumn({ length: 255 })
+  @IsString()
   @IsNotEmpty()
   @IsLowercase()
+  @MaxLength(255)
   public name!: string
 
   @Column({ name: 'tag_id' })
+  @IsNumber({ maxDecimalPlaces: 0 })
   public tagId!: number
 
   @ManyToOne(() => Tag, tag => tag.names, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'tag_id' })
+  @ValidateIf(tagName => typeof tagName.tag !== 'undefined')
+  @ValidateNested()
   public tag?: Tag
 
   public get id (): string {

--- a/src/entities/tag.ts
+++ b/src/entities/tag.ts
@@ -1,24 +1,33 @@
 import { Column, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm'
+import { IsNotEmpty, IsNumber, IsNumberString, IsString, MaxLength, ValidateIf, ValidateNested } from 'class-validator'
 import Guild from './guild'
-import { IsNotEmpty } from 'class-validator'
 import TagName from './tag-name'
 
 @Entity('tags')
 export default class Tag {
   @PrimaryGeneratedColumn()
+  @ValidateIf(tag => typeof tag.id !== 'undefined')
+  @IsNumber({ maxDecimalPlaces: 0 })
   public readonly id!: number
 
   @Column({ length: 7000 })
+  @IsString()
   @IsNotEmpty()
+  @MaxLength(70000)
   public content!: string
 
   @Column('bigint', { name: 'guild_id' })
+  @IsNumberString({ no_symbols: true })
   public guildId!: string
 
   @ManyToOne(() => Guild, guild => guild.roleMessages, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'guild_id' })
+  @ValidateIf(tag => typeof tag.guild !== 'undefined')
+  @ValidateNested()
   public guild?: Guild
 
   @OneToMany(() => TagName, tagName => tagName.tag, { cascade: true })
+  @ValidateIf(tag => typeof tag.names !== 'undefined')
+  @ValidateNested()
   public names?: TagName[]
 }

--- a/src/entities/ticket-type.ts
+++ b/src/entities/ticket-type.ts
@@ -1,32 +1,54 @@
 import { Column, Entity, JoinColumn, ManyToOne, OneToMany, OneToOne, PrimaryGeneratedColumn } from 'typeorm'
+import {
+  IsNotEmpty,
+  IsNumber,
+  IsNumberString,
+  IsOptional,
+  IsString,
+  MaxLength,
+  ValidateIf,
+  ValidateNested
+} from 'class-validator'
 import Guild from './guild'
-import { IsNotEmpty } from 'class-validator'
 import Message from './message'
 import Ticket from './ticket'
 
 @Entity('ticket_types')
 export default class TicketType {
   @PrimaryGeneratedColumn()
+  @ValidateIf(ticketType => typeof ticketType.id !== 'undefined')
+  @IsNumber({ maxDecimalPlaces: 0 })
   public readonly id!: number
 
   @Column({ length: 16 })
+  @IsString()
   @IsNotEmpty()
+  @MaxLength(16)
   public name!: string
 
   @Column('bigint', { name: 'guild_id' })
+  @IsNumberString({ no_symbols: true })
   public guildId!: string
 
   @Column('bigint', { name: 'message_id' })
+  @IsOptional()
+  @IsNumberString({ no_symbols: true })
   public messageId?: string | null
 
   @ManyToOne(() => Guild, guild => guild.ticketTypes, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'guild_id' })
+  @ValidateIf(ticketType => typeof ticketType.guild !== 'undefined')
+  @ValidateNested()
   public guild?: Guild
 
   @OneToOne(() => Message, message => message.ticketType, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'message_id' })
+  @IsOptional()
+  @IsNumberString({ no_symbols: true })
   public message?: Message | null
 
   @OneToMany(() => Ticket, ticket => ticket.type)
+  @ValidateIf(ticketType => typeof ticketType.tickets !== 'undefined')
+  @ValidateNested()
   public tickets?: Ticket[]
 }

--- a/src/entities/ticket.ts
+++ b/src/entities/ticket.ts
@@ -1,4 +1,5 @@
 import { Column, Entity, JoinColumn, ManyToMany, ManyToOne, OneToOne, PrimaryGeneratedColumn } from 'typeorm'
+import { IsNumber, IsNumberString, IsOptional, ValidateIf, ValidateNested } from 'class-validator'
 import Channel from './channel'
 import Guild from './guild'
 import Member from './member'
@@ -7,36 +8,54 @@ import TicketType from './ticket-type'
 @Entity('tickets')
 export default class Ticket {
   @PrimaryGeneratedColumn()
+  @ValidateIf(ticket => typeof ticket.id !== 'undefined')
+  @IsNumber({ maxDecimalPlaces: 0 })
   public readonly id!: number
 
   @Column('int', { name: 'author_id' })
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 0 })
   public authorId?: number | null
 
   @Column('bigint', { name: 'channel_id', nullable: true })
+  @IsNumberString({ no_symbols: true })
   public channelId!: string
 
   @Column('int', { name: 'type_id', nullable: true })
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 0 })
   public typeId?: number | null
 
   @Column('bigint', { name: 'guild_id' })
+  @IsNumberString({ no_symbols: true })
   public guildId!: string
 
   @ManyToOne(() => Guild, guild => guild.roles, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'guild_id' })
+  @ValidateIf(ticket => typeof ticket.guild !== 'undefined')
+  @ValidateNested()
   public guild?: Guild
 
   @ManyToMany(() => Member, member => member.moderatingTickets)
+  @ValidateIf(ticket => typeof ticket.moderators !== 'undefined')
+  @ValidateNested()
   public moderators?: Member[]
 
   @ManyToOne(() => Member, member => member.tickets, { onDelete: 'CASCADE' }) // FIXME: should be SET NULL
   @JoinColumn({ name: 'author_id' })
+  @IsOptional()
+  @ValidateNested()
   public author?: Member | null
 
   @OneToOne(() => Channel, channel => channel.ticket, { onDelete: 'SET NULL' }) // FIXME: should be CASCADE
   @JoinColumn({ name: 'channel_id' })
+  @ValidateIf(ticket => typeof ticket.channel !== 'undefined')
+  @ValidateNested()
   public channel?: Channel
 
   @ManyToOne(() => TicketType, ticketType => ticketType.tickets, { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'type_id' })
+  @IsOptional()
+  @ValidateNested()
   public type?: TicketType | null
 }


### PR DESCRIPTION
`class-validator` enabled `forbidUnknownValues` by default as of https://github.com/typestack/class-validator/pull/1798 because of a CVE. I thought [this](https://github.com/guidojw/arora-discord/pull/522) could be merged as-is but this happened to not be the case and some TypeORM saving broke. This PR fixes this bug by specifying validation decorators on all entity fields, so that they're not unknown to `class-validator` anymore.