### PR TITLE
feat: support merge queue

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [staging, main]
   pull_request:
+  merge_group:
   workflow_call:
     inputs:
       sha:


### PR DESCRIPTION
The merge queue creates temporary branches to run the CI on, and expects status checks on these. With this feature, a new event `merge_group` came into existence that triggers when these branches are created, this PR adds that event to the CI workflow.

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions
