### PR TITLE
fix: don't set sourcemap dist in publish image workflow

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -102,7 +102,6 @@ jobs:
         with:
           finalize: false
           sourcemaps: sourcemaps
-          dist: ${{ inputs.sha }}
           version: ${{ inputs.sha }}
           url_prefix: ~/dist
 


### PR DESCRIPTION
Figured this is not necessary.