### PR TITLE
fix(GuildTicketManager): set permissionOverwrites on channel create

### DIFF
--- a/src/managers/guild-ticket.ts
+++ b/src/managers/guild-ticket.ts
@@ -2,6 +2,7 @@ import {
   type ButtonInteraction,
   EmbedBuilder,
   type GuildMemberResolvable,
+  PermissionsBitField,
   TextChannel,
   type TextChannelResolvable
 } from 'discord.js'
@@ -61,9 +62,14 @@ export default class GuildTicketManager extends DataManager<number, Ticket, Tick
     try {
       channel = await this.context.guild.channels.create({
         name: channelName,
-        parent: this.context.ticketsCategory ?? undefined
+        parent: this.context.ticketsCategory ?? undefined,
+        permissionOverwrites: [
+          {
+            id: author.id,
+            allow: PermissionsBitField.Flags.ViewChannel
+          }
+        ]
       })
-      await channel.permissionOverwrites.edit(author, { ViewChannel: true })
     } catch (err) {
       await channel?.delete()
       throw err


### PR DESCRIPTION
Hopefully fixes bug that started showing up 25th of may where ticket creators don't get permissions to the tickets themselves.