### PR TITLE
refactor(GuildTicketManager): set permissionOverwrites in channel create call

### DIFF
--- a/src/managers/guild-ticket.ts
+++ b/src/managers/guild-ticket.ts
@@ -16,7 +16,7 @@ import { constants } from '../utils'
 
 const { TYPES } = constants
 
-const TICKETS_INTERVAL = 3_000
+const TICKETS_INTERVAL = 60_000
 const SUBMISSION_TIME = 3_600_000
 
 export type TicketResolvable = TextChannelResolvable | GuildMemberResolvable | Ticket | number


### PR DESCRIPTION
After #569, half of the created tickets were functioning correctly again, but not all of them. I found out that you can set a channel's permissionOverwrites directly in the create request so trying that here.