### PR TITLE
feat(client): application migrations

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,5 +1,7 @@
+export * from './migrations'
 export * from './websocket'
 export * as eventHandlers from './events'
+export * as migrations from './migrations'
 export type { default as BaseHandler } from './base'
 export { default as AroraClient } from './client'
 export { default as Dispatcher } from './dispatcher'

--- a/src/client/migrations/base.ts
+++ b/src/client/migrations/base.ts
@@ -1,0 +1,8 @@
+import type { AroraClient } from '..'
+import type { QueryRunner } from 'typeorm'
+
+export default interface BaseMigration {
+  shouldRun? (client: AroraClient, queryRunner?: QueryRunner): boolean | Promise<boolean>
+  run (client: AroraClient, queryRunner?: QueryRunner): void | Promise<void>
+  revert (client: AroraClient, queryRunner?: QueryRunner): void | Promise<void>
+}

--- a/src/client/migrations/index.ts
+++ b/src/client/migrations/index.ts
@@ -1,0 +1,1 @@
+export type { default as BaseMigration } from './base'

--- a/src/configs/container.ts
+++ b/src/configs/container.ts
@@ -8,6 +8,7 @@ import { Argument, type ArgumentOptions, type BaseCommand } from '../interaction
 import {
   AroraClient,
   type BaseHandler,
+  type BaseMigration,
   Dispatcher,
   SettingProvider,
   WebSocketManager,
@@ -291,6 +292,21 @@ bind<interfaces.MultiFactory<managers.BaseManager<number | string, any, unknown>
     }
   }
 )
+
+// Migrations
+container.onActivation(TYPES.Migration, (_context: interfaces.Context, migration: BaseMigration) => {
+  const handler = {
+    apply: function (target: (...args: any[]) => any, thisArgument: BaseMigration, argumentsList: any[]) {
+      return target.apply(thisArgument, [...argumentsList, dataSource.createQueryRunner()])
+    }
+  }
+  if (typeof migration.shouldRun !== 'undefined') {
+    migration.shouldRun = new Proxy(migration.shouldRun, handler)
+  }
+  migration.run = new Proxy(migration.run, handler)
+  migration.revert = new Proxy(migration.revert, handler)
+  return migration
+})
 
 // Structures
 bind<structures.ChannelGroup>(TYPES.Structure).to(structures.ChannelGroup)

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -25,6 +25,8 @@ export const TYPES = {
   Manager: Symbol.for('Manager'),
   ManagerFactory: Symbol.for('ManagerFactory'),
 
+  Migration: Symbol.for('Migration'),
+
   Structure: Symbol.for('Structure'),
   StructureFactory: Symbol.for('StructureFactory'),
 


### PR DESCRIPTION
Adds the option to run application migrations in the code, useful for e.g. migrating Discord resources after the database migrations have run. 
Added an activation handler on the new migration service identifier that automatically passes a query runner to the migrations, so that the client does not have to instance one.